### PR TITLE
fix(auth): return 401 for unauthenticated LoggedIn routes

### DIFF
--- a/src/logged-in.guard.ts
+++ b/src/logged-in.guard.ts
@@ -1,4 +1,4 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { getRequestFromExecutionContext } from './utils';
 
 /**
@@ -11,6 +11,9 @@ export class LoggedInGuard implements CanActivate {
   canActivate(context: ExecutionContext) {
     const req = getRequestFromExecutionContext(context);
     const user = req?.user;
-    return !!user;
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    return true;
   }
 }

--- a/test/auth-gql.e2e-spec.ts
+++ b/test/auth-gql.e2e-spec.ts
@@ -315,4 +315,27 @@ describe('AuthModule Tests for GraphQL', () => {
 
     expect(body).not.toHaveProperty('errors');
   });
+
+  it('should reject access to logged-in query without authentication', async () => {
+    const { body } = await client(gql`
+        query {
+            needLogin2
+        }
+    `).expect(200);
+
+    expect(body).toHaveProperty('errors');
+    expect(body.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('should access logged-in query with a valid jwt', async () => {
+    const { body } = await client(gql`
+        query {
+            needLogin2
+        }
+    `)
+    .auth(token, { type: 'bearer' })
+    .expect(200);
+
+    expect(body).not.toHaveProperty('errors');
+  });
 });

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -52,6 +52,7 @@
  */
 
 import { Body, Controller, Get, HttpCode, HttpStatus, INestApplication, Logger, Module, Post, Req } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
 import { AuthModule, Authorized, AuthService, CurrentUser, LoggedIn } from '../src';
@@ -284,5 +285,50 @@ describe('AuthModule Tests', function() {
       .get('/test2/need-login2')
       .auth('test', 'test')
       .expect(200);
+  });
+
+  it('should reject access to logged-in route without authentication', async () => {
+    await request(app.getHttpServer())
+      .get('/test2/need-login2')
+      .expect(401);
+  });
+
+  it('should access logged-in route with a valid jwt', async () => {
+    await request(app.getHttpServer())
+      .get('/test2/need-login2')
+      .auth(token, { type: 'bearer' })
+      .expect(200);
+  });
+
+  it('should reject a jwt with an invalid signature as unauthorized', async () => {
+    const invalidToken = new JwtService({
+      secret: 'wrong-secret',
+      signOptions: {
+        issuer: 'demo',
+        audience: ['demo'],
+        expiresIn: '7d',
+      },
+    }).sign({ uid: 0, sub: 'test', roles: ['A', 'B', 'U'] });
+
+    await request(app.getHttpServer())
+      .get('/test2/need-login2')
+      .auth(invalidToken, { type: 'bearer' })
+      .expect(401);
+  });
+
+  it('should reject an expired jwt as unauthorized', async () => {
+    const expiredToken = new JwtService({
+      secret: 'demo',
+      signOptions: {
+        issuer: 'demo',
+        audience: ['demo'],
+        expiresIn: -1,
+      },
+    }).sign({ uid: 0, sub: 'test', roles: ['A', 'B', 'U'] });
+
+    await request(app.getHttpServer())
+      .get('/test2/need-login2')
+      .auth(expiredToken, { type: 'bearer' })
+      .expect(401);
   });
 });


### PR DESCRIPTION
## Summary

- throw `UnauthorizedException` when `@LoggedIn()` has no authenticated user instead of returning `false` and letting Nest convert it to 403
- preserve JWT and Basic Auth guard fallthrough behavior for multi-strategy authentication
- add real Nest HTTP and GraphQL e2e coverage for missing, invalid-signature, expired, and valid JWT authentication

## Behavior

- missing, expired, or invalid JWT: 401 / `UNAUTHENTICATED`
- valid JWT without a required role: remains 403 / `FORBIDDEN`
- valid JWT or Basic Auth on `@LoggedIn()`: succeeds

## Test plan

- [x] `npm test -- --runInBand` (37 tests)
- [x] `npm run build`
- [x] `git diff --check`